### PR TITLE
Issue 1: Error on non-existent column in toHaveColumnValuesInSet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Run TypeScript compilation
         run: npm run build
 
+      - name: Run eslint & prettier
+        run: npm run lint && npm run format:check
+
       - name: Run tests
-        run: npm run test   
+        run: npm run test
 
       - name: Upload Jest coverage report
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dist
 .pnp.*
 
 src/.DS_Store
+
+# JetBrains project file
+.idea

--- a/src/table-to-have.ts
+++ b/src/table-to-have.ts
@@ -473,12 +473,14 @@ export const toHaveTableToMatch = (tableData1: TableData, tableData2: TableData)
  * toHaveColumnValuesInSet
  *
  * Asserts that all values in a specified column of table data match a set of valid values.
+ * Throws an error if the column header does not exist in a table row.
  * Throws an error if any value in the column is not in the provided set.
  *
  * @param tableData - Array of rows, each represented as an object with key-value pairs.
  * @param columnHeader - The column header to check. Must be a key in `tableData`.
  * @param targetSet - A Set of valid values for the column.
  *
+ * @throws Error - If the column header is not in a `tableData` row.
  * @throws Error - If any value in the column is not in `targetSet`.
  *
  * @example
@@ -498,8 +500,13 @@ export const toHaveColumnValuesInSet = (
   targetSet: Set<string>,
 ) => {
   tableData.forEach((row) => {
+    if (!(columnHeader in row)) {
+      throw new Error(`Column header "${columnHeader}" was not found in row ${JSON.stringify(row)}`);
+    }
+
     const cellValue = row[columnHeader];
-    if (cellValue !== undefined && !targetSet.has(cellValue)) {
+
+    if (!targetSet.has(cellValue)) {
       throw new Error(`Column "${columnHeader}" has a value "${cellValue}" which is not in the expected set.`);
     }
   });

--- a/src/test/to-have.spec.ts
+++ b/src/test/to-have.spec.ts
@@ -233,3 +233,17 @@ test('should have all Likes in the provided set', async () => {
   // Assert
   toHaveColumnValuesInSet(dataFrame, 'Likes', allowedLikesSet);
 });
+
+test('should throw error when asserting column values in set for non-existent column', async () => {
+  // Arrange
+  const htmlString = await getHTMLFile('table.html');
+
+  // Act
+  const dataFrame = toDataFrame(htmlString);
+
+  const allowedLikesSet = new Set(['HTML tables', 'Web accessibility', 'JavaScript frameworks', 'Web performance']);
+  const expectedError = `Column header "Non-existent Column" was not found in row ${JSON.stringify(dataFrame[0])}`;
+
+  // Assert
+  expect(() => toHaveColumnValuesInSet(dataFrame, 'Non-existent Column', allowedLikesSet)).toThrow(expectedError);
+});


### PR DESCRIPTION
Fix for Issue #1.

The `toHaveColumnValuesInSet` assertion checks that the column header exists on each row before checking the value against the target set. An error is thrown as soon as a header is not found, containing the expected header and the row content.